### PR TITLE
Add EPEL with Redhat Developer Toolkit compilers

### DIFF
--- a/centos6-epel-rdt/Dockerfile
+++ b/centos6-epel-rdt/Dockerfile
@@ -1,0 +1,15 @@
+FROM centos:centos6
+
+RUN useradd docker
+
+RUN \
+  yum install -y epel-release && \
+  yum install -y xorg-x11-server-Xvfb R-devel
+
+RUN \
+  yum install -y centos-release-scl && \
+  yum install -y devtoolset-4-gcc-c++
+
+RUN echo "source /opt/rh/devtoolset-4/enable" >> /etc/bashrc
+
+ENV RHUB_PLATFORM linux-x86_64-centos6-epel

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -14,7 +14,9 @@ docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 ./build-image.sh fedora-clang-devel || true
 ./build-image.sh fedora-gcc         || true
 ./build-image.sh fedora-gcc-devel   || true
+
 ./build-image.sh centos6-epel       || true
+./build-image.sh centos6-epel-rdt   || true
 
 ./build-image.sh ubuntu             || true
 ./build-image.sh ubuntu-gcc         || true


### PR DESCRIPTION
This is a special variant of CentOS6 which enables the "redhat developer toolkit". This includes a copy of gcc 5 which is binary compatible with the gcc 4.4 that is included with centos 6 itself. CentOS users need this to compile C++11 code.

In order to use these compilers, the user has to source a script which set the `PATH` and `LD_LIBRARY_PATH` and other stuff to this new set of compilers. I am not sure what is the best way to ensure this script gets executed before R in rhub. I am not using:

```
ENV RBINARY source /opt/rh/devtoolset-4/enable && R
```
