### PR TITLE
update fedora

### DIFF
--- a/fedora-clang/Dockerfile
+++ b/fedora-clang/Dockerfile
@@ -1,6 +1,6 @@
 ## Emacs, make this -*- mode: sh; -*-
 
-FROM fedora:22
+FROM fedora:latest
 
 ## Set a default user. Available via runtime flag
 RUN useradd docker

--- a/fedora-gcc/Dockerfile
+++ b/fedora-gcc/Dockerfile
@@ -1,6 +1,6 @@
 ## Emacs, make this -*- mode: sh; -*-
 
-FROM fedora:22
+FROM fedora:latest
 
 ## Set a default user. Available via runtime flag
 RUN useradd docker


### PR DESCRIPTION
Fedora 22 is super old and deprecated. 24 is stable now.

<img width="656" alt="screen shot 2016-09-16 at 1 12 22 pm" src="https://cloud.githubusercontent.com/assets/216319/18584148/44bb07a8-7c0f-11e6-90c1-2e6196a43945.png">
