### PR TITLE
Include additional font packages for ubuntu

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -60,9 +60,6 @@ RUN apt-get update \
 		texlive-latex-extra \
 		texlive-latex-recommended \
 		tk8.6-dev \
-		t1-xfree86-nonfree \
-		ttf-xfree86-nonfree \
-		ttf-xfree86-nonfree-syriac \
 		valgrind \
 		unzip \
 		x11proto-core-dev \

--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -60,12 +60,17 @@ RUN apt-get update \
 		texlive-latex-extra \
 		texlive-latex-recommended \
 		tk8.6-dev \
+		t1-xfree86-nonfree \
+		ttf-xfree86-nonfree \
+		ttf-xfree86-nonfree-syriac \
 		valgrind \
 		unzip \
 		x11proto-core-dev \
 		xauth \
 		xdg-utils \
 		xfonts-base \
+		xfonts-100dpi \
+		xfonts-75dpi \
 		xvfb \
 		zlib1g-dev
 


### PR DESCRIPTION
ggplot2 fails on R-devel unless some combination of these is present (sorry I didn't narrow it down further). See https://github.com/rstudio/shiny/issues/2063