### PR TITLE
add images for CentOS 7 and 8

### DIFF
--- a/centos7-epel/Dockerfile
+++ b/centos7-epel/Dockerfile
@@ -1,0 +1,19 @@
+FROM centos:7
+
+RUN useradd docker
+
+RUN \
+  yum upgrade -y && \
+  yum install -y epel-release && \
+  yum install -y xorg-x11-server-Xvfb R-devel valgrind qpdf gcc-gfortran \
+    aspell aspell-en
+
+RUN curl -o /usr/bin/pandoc.gz \
+    https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
+  gzip -d /usr/bin/pandoc.gz && \
+  curl -o /usr/bin/pandoc-citeproc.gz \
+    https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
+  gzip -d /usr/bin/pandoc-citeproc.gz && \
+  chmod +x /usr/bin/pandoc /usr/bin/pandoc-citeproc
+
+ENV RHUB_PLATFORM linux-x86_64-centos7-epel

--- a/centos8-epel/Dockerfile
+++ b/centos8-epel/Dockerfile
@@ -1,0 +1,21 @@
+FROM centos:8
+
+RUN useradd docker
+
+RUN \
+  yum upgrade -y && \
+  yum install -y 'dnf-command(config-manager)' && \
+  yum config-manager --set-enabled PowerTools && \
+  yum install -y epel-release && \
+  yum install -y xorg-x11-server-Xvfb R-devel valgrind qpdf gcc-gfortran \
+    glibc-langpack-en aspell aspell-en
+
+RUN curl -o /usr/bin/pandoc.gz \
+    https://files.r-hub.io/pandoc/linux-64/pandoc.gz && \
+  gzip -d /usr/bin/pandoc.gz && \
+  curl -o /usr/bin/pandoc-citeproc.gz \
+    https://files.r-hub.io/pandoc/linux-64/pandoc-citeproc.gz && \
+  gzip -d /usr/bin/pandoc-citeproc.gz && \
+  chmod +x /usr/bin/pandoc /usr/bin/pandoc-citeproc
+
+ENV RHUB_PLATFORM linux-x86_64-centos8-epel


### PR DESCRIPTION
CentOS 6 is entering it's last year of extended support so most servers have moved on to CentOS 7 or 8. We still use R from EPEL which is what most servers will be using.