### PR TITLE
Use libc++ on fedora-clang-devel

### DIFF
--- a/fedora-clang-devel/Dockerfile
+++ b/fedora-clang-devel/Dockerfile
@@ -33,4 +33,10 @@ COPY xvfb-run /usr/local/bin/xvfb-run
 RUN chmod +x /usr/local/bin/xvfb-run && \
     rm -f /bin/xvfb-run /usr/bin/xvfb-run
 
+# fedora-clang-devel on CRAN uses a special clang compiled to use libc++
+# https://www.stats.ox.ac.uk/pub/bdr/Rconfig/r-devel-linux-x86_64-fedora-clang
+RUN dnf install -y libcxx-devel && \
+    sed -i.bak -E -e 's/(CXX1?1? =.*)/\1 -stdlib=libc++/g' $($RPREFIX/bin/R RHOME)/etc/Makeconf && \
+    rm -rf $($RPREFIX/bin/R RHOME)/etc/Makeconf.bak
+
 ENV RHUB_PLATFORM linux-x86_64-fedora-clang


### PR DESCRIPTION
CRAN uses a custom `clang` that uses `libc++` on this test machine. If you build any dependencies and don't use that `clang`, the build may fail with undefined symbols errors (such as [this](https://www.r-project.org/nosvn/R.check/r-devel-linux-x86_64-fedora-clang/arrow-00install.html)). In https://github.com/apache/arrow/pull/7694 I patched the rhub image we use in CI to force `libc++`, as proposed here, which reproduced my error. 

There's probably a more elegant way to do this, but it seemed to work. Also, https://www.stats.ox.ac.uk/pub/bdr/Rconfig/r-devel-linux-x86_64-fedora-clang mentions other config/flags that maybe should be set in this image, but I didn't need to deal with that to reproduce and fix my issue. 