### PR TITLE
Use `-stdlib=libc++` on fedora-clang-devel

### DIFF
--- a/fedora-clang-devel/Dockerfile
+++ b/fedora-clang-devel/Dockerfile
@@ -33,4 +33,10 @@ COPY xvfb-run /usr/local/bin/xvfb-run
 RUN chmod +x /usr/local/bin/xvfb-run && \
     rm -f /bin/xvfb-run /usr/bin/xvfb-run
 
+# fedora-clang-devel on CRAN uses a special clang compiled to use libc++
+# https://www.stats.ox.ac.uk/pub/bdr/Rconfig/r-devel-linux-x86_64-fedora-clang
+RUN dnf install -y libcxx-devel
+RUN mkdir -p /root/.R
+COPY Makevars /root/.R/Makevars
+
 ENV RHUB_PLATFORM linux-x86_64-fedora-clang

--- a/fedora-clang-devel/Makevars
+++ b/fedora-clang-devel/Makevars
@@ -1,0 +1,5 @@
+CXX += -stdlib=libc++
+CXX11 += -stdlib=libc++
+CXX14 += -stdlib=libc++
+CXX17 += -stdlib=libc++
+CXX20 += -stdlib=libc++


### PR DESCRIPTION
This is a slightly modified version of #52 that uses a slightly different way to update the Makevars (in this case, CXX and family). The gist of it is that the fedora-clang-devel check is using a custom build of clang that can be replicated using `-stdlib=libc++` (this is the suggested method according to https://www.stats.ox.ac.uk/pub/bdr/Rconfig/r-devel-linux-x86_64-fedora-clang ). I copied the Makevars addition from the debian-gcc10-devel image, which also updates the Makevars. I checked this using:

```bash
docker build . --tag fedora-clang-devel
docker run --rm -it fedora-clang-devel /opt/R-devel/bin/R CMD config CXX
docker run --rm -it fedora-clang-devel /opt/R-devel/bin/R CMD config CXX11
docker run --rm -it fedora-clang-devel /opt/R-devel/bin/R CMD config CXX14
docker run --rm -it fedora-clang-devel /opt/R-devel/bin/R CMD config CXX17
docker run --rm -it fedora-clang-devel /opt/R-devel/bin/R CMD config CXX20
```

We also ran into a problem installing the 'sass' package which we fixed by adding `-stdlib=libc++` to the LDFLAGS, but I think the root cause of that is that 'sass' isn't using CXX to do the linking (https://github.com/rstudio/sass/pull/104, https://github.com/apache/arrow/pull/12734).