### PR TITLE
fix Debian build errors related to 'useradd'

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -14,7 +14,7 @@ COPY checkbashisms /usr/local/bin
 RUN useradd docker \
 	&& mkdir /home/docker \
 	&& chown docker:docker /home/docker \
-	&& addgroup docker staff
+	&& usermod -a -G staff docker
 
 RUN apt-get update && apt-get -y upgrade
 


### PR DESCRIPTION
👋 Hi, I'm James, one of the maintainers of `{lightgbm}`.

We use the `rhub/debian-clang-devel` image in LightGBM's CI to try to replicate the `r-devel-linux-x86_64-debian-clang` CRAN check ([code link](https://github.com/microsoft/LightGBM/blob/3eb68e85e99a221b04c0e19eb262e41e210f3da1/.github/workflows/r_package.yml#L211)), and I investigated today why the version of R-devel we're getting in that image is from July 31st, 2022 (2+ months ago).

I noticed that this project's Debian builds have been failing since August 1st, with an error like this:

> addgroup: addgroup with two arguments is an unspecified operation.
> The command '/bin/sh -c useradd docker 	&& mkdir /home/docker 	&& chown docker:docker /home/docker 	&& addgroup docker staff' returned a non-zero code: 1

I *think* that's what #50 is referring to, but not sure.

<details><summary>screenshot (click me)</summary>

<p align="center">
<image src="https://user-images.githubusercontent.com/7608904/194642378-68da134e-fb20-410f-a0bd-74dad0a59d1a.png" width="65%">
</p>

source: https://github.com/r-hub/rhub-linux-builders/actions/workflows/debian.yml

</details>

This PR proposes a fix that I believe will allow them to succeed again.

## Impact of this change

As a result of those build failures, the last update of `rhub/debian-clang-devel` on DockerHub was August 1st.

<details><summary>screenshot (click me)</summary>

<p align="center">
<image src="https://user-images.githubusercontent.com/7608904/194642730-65299057-7935-4626-a4ae-c75d8c210570.png" width="65%">
</p>

source: https://hub.docker.com/r/rhub/debian-clang-devel/tags

</details>

That means that CRAN checks are using a version of R-devel that is 2+ months newer than the one in the `rhub/debian*:latest` images. 

As a result, users of those images (and the R Hub service, if it uses these images?) might find themselves in the situation we are in in `{lightgbm}`, where `R CMD check` passes using these images but fails on CRAN.

## Changes in this PR

* switch from `useradd` to `usermod -G` for adding `docker` user to the `staff` group in the `debian` images

## How I tested this

<details><summary>built the images locally, then ran `R CMD check --as-cran` on lightgbm (click for details)</summary>

```shell
# remove any lingering images from prior development
docker rmi -f rhub/debian-clang-devel

# pull base image
docker pull debian:testing

# build base image
pushd ./debian
    docker build \
        --no-cache \
        -t rhub/debian:local \
        .
popd

# build clang image
pushd ./debian-clang
  # switch base image to the one I just built locally
  sed \
    -i.bak \
    -e 's/FROM rhub\/debian/FROM rhub\/debian:local/g' \
    ./Dockerfile

  rm ./Dockerfile.bak

  # build
  docker build \
      --no-cache \
      -t rhub/debian-clang:local \
      .
popd

# build clang-devel image
pushd ./debian-clang-devel
  # switch base image to the one I just built locally
  sed \
    -i.bak \
    -e 's/FROM rhub\/debian-clang/FROM rhub\/debian-clang:local/g' \
    ./Dockerfile

  rm ./Dockerfile.bak

  # build
  docker build \
      --no-cache \
      -t rhub/debian-clang-devel:local \
      .
popd
```

Then, with those images built, I checked LightGBM v3.3.2 (the latest version on CRAN).

```shell
# check LightGBM
docker run \
    --rm \
    --entrypoint="" \
    -it rhub/debian-clang-devel:local \
    /bin/bash -c '
      curl -O "https://cran.r-project.org/src/contrib/lightgbm_3.3.2.tar.gz" &&
      /opt/R-devel/bin/Rscript -e "install.packages(c(\"data.table\", \"jsonlite\", \"Matrix\", \"R6\", \"testthat\"), repos = \"https://cran.r-project.org\")" &&
      /opt/R-devel/bin/R CMD check --as-cran ./lightgbm_3.3.2.tar.gz'
```

That failed with exactly the same error I see on CRAN!

```text
* checking tests ...
  Running 'testthat.R' [34s/34s]
 [34s/34s] ERROR
Running the tests in 'tests/testthat.R' failed.
Last 13 lines of output:
  x[1]: "F_�\u009b�"
  y[1]: "F_<U+96F6>"
  
  x[2]: "F_�\u0080"
  y[2]: "F_<U+4E00>"
  
  x[3]: "F_�\u008c"
  y[3]: "F_<U+4E8C>"
  
  x[4]: "F_�\u0089"
  y[4]: "F_<U+4E09>"
  
  == DONE ========================================================================
  Error: Test failures
  Execution halted
```

</details>

## Notes for Reviewers

Recently, we were notified by CRAN that `{lightgbm}` is failing that check on the latest R-devel. That prompted this investigation. Details if you're interested: https://github.com/microsoft/LightGBM/issues/5502

I rely so much on these images...I'd be happy to help fix the ~Ubuntu~ CentOS builds in a future PR as well, if you're interested.

Thanks very much for your time and consideration!