### PR TITLE
add 'tidy' to Debian images

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update \
 		texlive-latex-base \
 		texlive-latex-extra \
 		texlive-latex-recommended \
+        tidy \
 		tk8.6-dev \
 		valgrind \
 		unzip \


### PR DESCRIPTION
Since #62 was merged, I've observed that my package (`{lightgbm}`) has one NOTE from `R CMD check` when running on the Debian images.

```text
* checking HTML version of manual ... NOTE
Skipping checking HTML validation: no command 'tidy' found
...
Status: 1 NOTE
...
NOTEs, WARNINGs, or ERRORs have been found by R CMD check
```

ref: https://github.com/microsoft/LightGBM/issues/5587

A bit hard to tell, but I think this is related to some changes on r-devel's use of `tidy` ([link](https://www.html-tidy.org/)) that happened around late July ([this commit](https://github.com/wch/r-source/commit/b737dbe5f65b9829a7bdecbaad2b7478c26ce4da)).

This PR proposes adding `tidy` to the Debian images to resolve that NOTE.

### Notes for Reviewers

I expect that CRAN has `tidy` installed on its Linux machines, based on the following line in Section 1.3.1 of "Writing R Extensions" ([link](https://cran.r-project.org/doc/manuals/R-exts.html#Checking-packages)).

> Optionally (including by R CMD check --as-cran) the HTML version of the manual is created and checked for compliance with the HTML5 standard. This requires a recent version[52](https://cran.r-project.org/doc/manuals/R-exts.html#FOOT52) of ‘HTML Tidy’, either on the path or at a location specified by environment variable R_TIDYCMD. Up-to-date versions can be installed from http://binaries.html-tidy.org/.

Thanks for your time and consideration.