### PR TITLE
Fix invalid value of `Sys.timezone()`

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -1,6 +1,7 @@
 ## Emacs, make this -*- mode: sh; -*-
 
 FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
 
 MAINTAINER "r-hub admin" admin@r-hub.io
 


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/ARROW-18401 ( https://github.com/apache/arrow/pull/14894 ), we ended up with an error because in the rhub/ubuntu-based images, the value of `Sys.timezone()` is not a valid timezone (the value is "/UTC"). @assignUser tracked this down to the fact that the content of the file `"/etc/timezone"` was `"/UTC"`; Kou tracked down that this is due to the install of `tzdata` without a noninteractive frontend.

I tested this change with:

```
cd ubuntu
docker build . --tag rhub/ubuntu
docker run --rm -it rhub/ubuntu bash
# cat /etc/timezone
# apt-get update && apt-get install -y r-base
# Rscript -e 'Sys.timezone()'
```

Before this change, `Sys.timezone()` returns `"/UTC"`; after this change `Sys.timezone()` returns "Etc/UTC".