### PR TITLE
Sync fedora version with CRAN

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,6 +1,6 @@
 ## Emacs, make this -*- mode: sh; -*-
 
-FROM fedora:33
+FROM fedora:36
 
 
 ## Copy 'checkbashisms' (as a local copy from devscripts package)


### PR DESCRIPTION
See https://cran.r-project.org/web/checks/check_flavors.html#r-devel-linux-x86_64-fedora-gcc

