### PR TITLE
Tidy on Ubuntu

### DIFF
--- a/ubuntu/Dockerfile
+++ b/ubuntu/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update \
 		texlive-latex-base \
 		texlive-latex-extra \
 		texlive-latex-recommended \
+		tidy \
 		tk8.6-dev \
 		valgrind \
 		unzip \


### PR DESCRIPTION
Similar to #64 from @jameslamb (which added Tidy to Debian), this PR adds Tidy to Ubuntu.  I am receiving the note with `R CMD Check` on Ubuntu image runs in Github Actions CICD for (`{pkgnet}`). 

```
* using R version 4.3.3 (2024-02-29)
* using platform: x86_64-pc-linux-gnu (64-bit)
* R was compiled by
    gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0
    GNU Fortran (Ubuntu 11.4.0-1ubuntu1~[22](https://github.com/uptake/pkgnet/actions/runs/8560747421/job/23460433115#step:7:23).04) 11.4.0
* running under: Ubuntu 22.04.4 LTS
* using session charset: UTF-8
* using option ‘--as-cran’
[...]
* checking HTML version of manual ... NOTE
Skipping checking HTML validation: no command 'tidy' found
```

This PR should resolve that NOTE. 